### PR TITLE
v2 code started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# guggy
+
+Sample usage:
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/orijtech/guggy/v2"
+)
+
+func main() {
+	client, err := guggy.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.Search(&guggy.Request{
+		Query: "What is the weather up there?",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, gif := range res.Gifs {
+		fmt.Printf("GIF: %d %#v\n", i, gif)
+	}
+
+	for i, sticker := range res.Stickers {
+		fmt.Printf("Sticker: %d %#v\n", i, sticker)
+	}
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guggy_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/orijtech/guggy/v2"
+)
+
+func Example_client_Search() {
+	client, err := guggy.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.Search(&guggy.Request{
+		Query: "What is the weather up there?",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, gif := range res.Gifs {
+		fmt.Printf("GIF: %d %#v\n", i, gif)
+	}
+
+	for i, sticker := range res.Stickers {
+		fmt.Printf("Sticker: %d %#v\n", i, sticker)
+	}
+}

--- a/v2/guggy.go
+++ b/v2/guggy.go
@@ -1,0 +1,228 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guggy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/orijtech/otils"
+)
+
+const (
+	baseURL = "https://text2gif.guggy.com/v2"
+)
+
+type Client struct {
+	sync.RWMutex
+	apiKey string
+
+	rt http.RoundTripper
+}
+
+func (c *Client) httpClient() *http.Client {
+	c.RLock()
+	rt := c.rt
+	c.RUnlock()
+
+	return &http.Client{
+		Transport: rt,
+	}
+}
+
+func (c *Client) SetHTTPRoundTripper(rt http.RoundTripper) {
+	c.Lock()
+	c.rt = rt
+	c.Unlock()
+}
+
+func (c *Client) SetAPIKey(apiKey string) {
+	c.Lock()
+	c.apiKey = apiKey
+	c.Unlock()
+}
+
+var (
+	envAPIKeyKey      = "GUGGY_API_KEY"
+	errBlankEnvAPIKey = fmt.Errorf("expected %q to have been set in your environment", envAPIKeyKey)
+	errBlankAPIKey    = errors.New("expecting a non-blank apiKey")
+)
+
+func NewClientFromEnv() (*Client, error) {
+	apiKey := strings.TrimSpace(os.Getenv(envAPIKeyKey))
+	if apiKey == "" {
+		return nil, errBlankEnvAPIKey
+	}
+	return &Client{apiKey: apiKey}, nil
+}
+
+func NewClient(apiKey string) (*Client, error) {
+	if apiKey == "" {
+		return nil, errBlankAPIKey
+	}
+	return &Client{apiKey: apiKey}, nil
+}
+
+type Dimensions struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type Image struct {
+	URL string `json:"secureUrl,omitempty"`
+
+	Dimensions *Dimensions `json:"dimensions,omitempty"`
+}
+
+type Size struct {
+	Original *Image `json:"original"`
+	Preview  *Image `json:"preview"`
+
+	LowQuality *Image `json:"lowQuality"`
+
+	HighResolution *Image `json:"hires"`
+}
+
+type Collection struct {
+	GIF  *Size `json:"gif,omitempty"`
+	MP4  *Size `json:"mp4,omitempty"`
+	PNG  *Size `json:"png,omitempty"`
+	WEBP *Size `json:"webp,omitempty"`
+
+	Original *Size `json:"original"`
+
+	Thumbnail *Size `json:"thumbnail"`
+}
+
+type Response struct {
+	RequestID string        `json:"reqId"`
+	Stickers  []*Collection `json:"stickers"`
+	Gifs      []*Collection `json:"animated"`
+}
+
+type Request struct {
+	Query string `json:"query"`
+
+	Language Language `json:"lang"`
+}
+
+func (c *Client) _apiKey() string {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.apiKey
+}
+
+type request struct {
+	Terms    string   `json:"sentence"`
+	Language Language `json:"lang"`
+}
+
+var blankResponse = new(Response)
+
+var (
+	errBlankRequest  = errors.New("expecting a non-blank request")
+	errBlankResponse = errors.New("server sent back a blank response")
+)
+
+func (c *Client) Search(req *Request) (*Response, error) {
+	if req == nil {
+		return nil, errBlankRequest
+	}
+	rreq := &request{Terms: req.Query, Language: req.Language}
+	blob, err := json.Marshal(rreq)
+	if err != nil {
+		return nil, err
+	}
+	theURL := fmt.Sprintf("%s/guggify", baseURL)
+	httpReq, err := http.NewRequest("POST", theURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+	slurp, _, err := c.doAuthAndHTTPReq(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	resp := new(Response)
+	if err := json.Unmarshal(slurp, resp); err != nil {
+		return nil, err
+	}
+	if reflect.DeepEqual(resp, blankResponse) {
+		return nil, errBlankResponse
+	}
+	return resp, nil
+}
+
+func (c *Client) doAuthAndHTTPReq(req *http.Request) ([]byte, http.Header, error) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("apiKey", c._apiKey())
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+	if !otils.StatusOK(res.StatusCode) {
+		return nil, res.Header, errors.New(res.Status)
+	}
+	slurp, err := ioutil.ReadAll(res.Body)
+	return slurp, res.Header, err
+}
+
+// Languages
+type Language string
+
+const (
+	LangSpanish            Language = "es"
+	LangPortuguese         Language = "pt"
+	LangIndonesian         Language = "id"
+	LangFrench             Language = "fr"
+	LangArabic             Language = "ar"
+	LangTurkish            Language = "tr"
+	LangThai               Language = "th"
+	LangVietnamese         Language = "vi"
+	LangGerman             Language = "de"
+	LangItalian            Language = "it"
+	LangJapanese           Language = "ja"
+	LangChineseSimplified  Language = "zh-CN"
+	LangChineseTraditional Language = "zh-TW"
+	LangRussian            Language = "ru"
+	LangKorean             Language = "ko"
+	LangPolish             Language = "pl"
+	LangDutch              Language = "nl"
+	LangRomanian           Language = "ro"
+	LangHungarian          Language = "hu"
+	LangSwedish            Language = "sv"
+	LangCzech              Language = "cs"
+	LangHindi              Language = "hi"
+	LangBengali            Language = "bn"
+	LangDanish             Language = "da"
+	LangFarsi              Language = "fa"
+	LangFilipino           Language = "tl"
+	LangFinnish            Language = "fi"
+	LangHebrew             Language = "iw"
+	LangMalay              Language = "ms"
+	LangNorwegian          Language = "no"
+	LangUkrainian          Language = "uk"
+)

--- a/v2/guggy_test.go
+++ b/v2/guggy_test.go
@@ -1,0 +1,132 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guggy_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/orijtech/guggy/v2"
+)
+
+func TestSearch(t *testing.T) {
+	client, err := guggy.NewClient(testAPIKey1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetHTTPRoundTripper(&backend{route: searchRoute})
+
+	tests := [...]struct {
+		req     *guggy.Request
+		wantErr bool
+	}{
+		0: {wantErr: true},
+		1: {req: &guggy.Request{Query: "say what?"}},
+	}
+
+	for i, tt := range tests {
+		res, err := client.Search(tt.req)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: expected non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d gotErr: %v", i, err)
+			continue
+		}
+		if res == nil {
+			t.Errorf("#%d expected a non-blank response", i)
+			continue
+		}
+	}
+}
+
+var errUnimplemented = errors.New("unimplemented")
+
+type backend struct {
+	route string
+}
+
+func (b *backend) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch b.route {
+	case searchRoute:
+		return b.searchRoundTrip(req)
+	default:
+		return nil, errUnimplemented
+	}
+}
+
+func makeResp(status string, code int, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		Status:     status,
+		StatusCode: code,
+		Body:       body,
+		Header:     make(http.Header),
+	}
+}
+
+func checkAuthAndMethod(req *http.Request, wantMethod string) (*http.Response, error) {
+	if req.Method != wantMethod {
+		return makeResp(fmt.Sprintf("got method %q want %q", req.Method, wantMethod), http.StatusMethodNotAllowed, nil), nil
+	}
+	apiKey := strings.TrimSpace(req.Header.Get("apiKey"))
+	if apiKey == "" {
+		return makeResp(`expected "apiKey" in the header`, http.StatusBadRequest, nil), nil
+	}
+	switch apiKey {
+	case testAPIKey1, testAPIKey2:
+		return nil, nil
+	default:
+		return makeResp("unauthorized API key", http.StatusUnauthorized, nil), nil
+	}
+}
+
+var blankRequest = new(guggy.Request)
+
+func (b *backend) searchRoundTrip(req *http.Request) (*http.Response, error) {
+	if badAuthResp, err := checkAuthAndMethod(req, "POST"); badAuthResp != nil || err != nil {
+		return badAuthResp, err
+	}
+
+	defer req.Body.Close()
+	slurp, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	if len(slurp) < 6 {
+		return makeResp("expecting a non-blank Request", http.StatusBadRequest, nil), nil
+	}
+	f, err := os.Open("./testdata/search-0.json")
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	return makeResp("200 OK", http.StatusOK, f), nil
+}
+
+const (
+	testAPIKey1 = "test-api-key-1"
+	testAPIKey2 = "test-api-key-2"
+
+	searchRoute = "/search"
+)

--- a/v2/testdata/search-0.json
+++ b/v2/testdata/search-0.json
@@ -1,0 +1,117 @@
+{
+  "reqId": "HrKANFARqj",
+  "animated": [
+    {
+      "gif": {
+        "preview": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/animated/0/p/guggy.gif",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/animated/0/p/guggy.gif",
+          "dimensions": {
+            "width": 130,
+            "height": 94
+          }
+        },
+        "lowQuality": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/animated/0/l/guggy.gif",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/animated/0/l/guggy.gif",
+          "dimensions": {
+            "width": 250,
+            "height": 180
+          }
+        },
+        "original": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/animated/0/o/guggy.gif",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/animated/0/o/guggy.gif",
+          "dimensions": {
+            "width": 250,
+            "height": 180
+          }
+        }
+      },
+      "mp4": {
+        "original": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/animated/0/o/guggy.mp4",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/animated/0/o/guggy.mp4",
+          "dimensions": {
+            "width": 250,
+            "height": 180
+          }
+        },
+        "preview": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/animated/0/p/guggy.mp4",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/animated/0/p/guggy.mp4",
+          "dimensions": {
+            "width": 130,
+            "height": 94
+          }
+        }
+      },
+      "thumbnail": {
+        "original": {
+          "url": "http://guggyrepository.guggy.com/NbPBGAkQToGyOdGtLUHJ.jpg",
+          "secureUrl": "https://guggyrepository.guggy.com/NbPBGAkQToGyOdGtLUHJ.jpg",
+          "dimensions": {
+            "width": 250,
+            "height": 180
+          }
+        }
+      }
+    }
+  ],
+  "sticker": [
+    {
+      "webp": {
+        "hires": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/h/guggy.webp",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/h/guggy.webp",
+          "dimensions": {
+            "width": 512,
+            "height": 512
+          }
+        },
+        "original": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/o/guggy.webp",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/o/guggy.webp",
+          "dimensions": {
+            "width": 256,
+            "height": 256
+          }
+        },
+        "preview": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/p/guggy.webp",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/p/guggy.webp",
+          "dimensions": {
+            "width": 128,
+            "height": 128
+          }
+        }
+      },
+      "png": {
+        "hires": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/h/guggy.png",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/h/guggy.png",
+          "dimensions": {
+            "width": 512,
+            "height": 512
+          }
+        },
+        "original": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/o/guggy.png",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/o/guggy.png",
+          "dimensions": {
+            "width": 256,
+            "height": 256
+          }
+        },
+        "preview": {
+          "url": "http://img.guggy.com/media/HrKANFARqj/sticker/0/p/guggy.png",
+          "secureUrl": "https://img.guggy.com/media/HrKANFARqj/sticker/0/p/guggy.png",
+          "dimensions": {
+            "width": 128,
+            "height": 128
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implemented Search of the /v2 Guggy API.

Sample usage:
```go
package main

import (
	"fmt"
	"log"

	"github.com/orijtech/guggy/v2"
)

func main() {
	client, err := guggy.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	res, err := client.Search(&guggy.Request{
		Query: "What is the weather up there?",
	})
	if err != nil {
		log.Fatal(err)
	}

	for i, gif := range res.Gifs {
		fmt.Printf("GIF: %d %#v\n", i, gif)
	}

	for i, sticker := range res.Stickers {
		fmt.Printf("Sticker: %d %#v\n", i, sticker)
	}
}
```